### PR TITLE
Add vim to the container for file edits

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,7 @@ max_line_length = 120
 
 [*.{yml,yaml}]
 indent_size = 2
+
+[*.sh]
+indent_size = 2
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+*.sh text eol=lf

--- a/SpinnakerHalyard/SpinnakerHalyard.psm1
+++ b/SpinnakerHalyard/SpinnakerHalyard.psm1
@@ -87,8 +87,13 @@ function Start-Halyard {
       -v "${HOME}/.kube:/home/spinnaker/.kube:ro" `
       -v "halyard:/home/spinnaker/.hal" `
       -v "$(GetBackupPath):/home/spinnaker/halbackups" `
+      -v "${PSScriptRoot}:/home/spinnaker/scripts" `
       ${Registry}:$Version
 
+    CheckExitCode
+
+    # Ensure vim is installed for file editing during Connect-Halyard
+    & docker exec -u root:root $ContainerName /home/spinnaker/scripts/setup.sh
     CheckExitCode
 
     # Wait for daemon to startup for 30 seconds
@@ -131,7 +136,7 @@ None.
 Stop-Halyard
 #>
 function Stop-Halyard {
-  [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact="Low")]
+  [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact="Medium")]
   Param()
 
   if ((Test-Halyard) -and $PSCmdlet.ShouldProcess($ContainerName)) {

--- a/SpinnakerHalyard/setup.sh
+++ b/SpinnakerHalyard/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+apt-get update
+apt-get install -y vim


### PR DESCRIPTION
Motivation
----------
The official Halyard image doesn't include vim, so using Connect-Halyard
to edit files directly is difficult.

Modifications
-------------
Install vim during container startup.